### PR TITLE
Upgrade to Go 1.23 and other updates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,16 +28,12 @@ linters-settings:
         sizeThreshold: 512
   gocyclo:
     min-complexity: 16
-  golint:
-    min-confidence: 0
-  govet:
-    check-shadowing: false
   lll:
     line-length: 300
-  maligned:
-    suggest-new: true
   misspell:
     locale: US
+  revive:
+    min-confidence: 0
 
 issues:
   exclude-rules:
@@ -50,40 +46,33 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - deadcode
-    - depguard
+    - copyloopvar
     - dogsled
     - dupl
     - errcheck
     - exhaustive
-    - exportloopref
     - gochecknoinits
     - goconst
     - gocritic
     - godot
     - gofmt
-    - golint
     - goprintffuncname
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - lll
-    - maligned
     - misspell
     - nakedret
     - nolintlint
     - prealloc
+    - revive
     - rowserrcheck
-    - scopelint
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,14 @@ deps: ## download go modules
 
 .PHONY: fmt
 fmt: ## ensure consistent code style
-	go run oss.indeed.com/go/go-groups@v1.1.2 -w .
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2 run --fix > /dev/null 2>&1 || true
+	go run oss.indeed.com/go/go-groups@v1.1.3 -w .
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --fix > /dev/null 2>&1 || true
 	go mod tidy
 
 .PHONY: lint
 lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2 run
-	@if [ -n "$$(go run oss.indeed.com/go/go-groups@v1.1.2 -l .)" ]; then \
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run
+	@if [ -n "$$(go run oss.indeed.com/go/go-groups@v1.1.3 -l .)" ]; then \
 		echo -e "\033[0;33mdetected fmt problems: run \`\033[0;32mmake fmt\033[0m\033[0;33m\`\033[0m"; \
 		exit 1; \
 	fi

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,13 @@
 module oss.indeed.com/go/go-opine
 
-go 1.17
+go 1.23.0
+
+toolchain go1.23.1
 
 require (
 	github.com/google/subcommands v1.2.0
 	github.com/stretchr/testify v1.7.1
-	golang.org/x/tools v0.1.10
+	golang.org/x/tools v0.31.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.10 h1:QjFRCZxdOhBJ/UNgnBZLbNV13DlbnK0quyivTnXJM20=
 golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
+golang.org/x/tools v0.31.0 h1:0EedkvKDbh+qistFTd0Bcwe/YLh4vHwWEkiI0toFIBU=
+golang.org/x/tools v0.31.0/go.mod h1:naFTU+Cev749tSJRXJlna0T3WxKvb1kWEx15xA4SdmQ=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/cmd/test.go
+++ b/internal/cmd/test.go
@@ -67,6 +67,7 @@ func (t *testCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&t.norace, "norace", false, "compile tests with race detector disabled")
 }
 
+//revive:disable:unused-parameter
 func (t *testCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
 	return executeNoArgs(f, t.impl)
 }

--- a/internal/cmd/test_test.go
+++ b/internal/cmd/test_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +13,7 @@ func Test_TestCmd_impl(t *testing.T) {
 	popd := pushd(t, "testdata", "go-library")
 	defer popd()
 
-	outDir, err := ioutil.TempDir("", "go-opine-cmd-test.")
+	outDir, err := os.MkdirTemp("", "go-opine-cmd-test.")
 	require.NoError(t, err)
 	defer os.RemoveAll(outDir)
 
@@ -46,7 +45,7 @@ func Test_TestCmd_impl_xmlcovWithoutCoverprofile(t *testing.T) {
 	popd := pushd(t, "testdata", "go-library")
 	defer popd()
 
-	outDir, err := ioutil.TempDir("", "go-opine-cmd-test.")
+	outDir, err := os.MkdirTemp("", "go-opine-cmd-test.")
 	require.NoError(t, err)
 	defer os.RemoveAll(outDir)
 
@@ -120,7 +119,7 @@ func Test_TestCmd_impl_outputsStillWrittenWhenTestsFail(t *testing.T) {
 	popd := pushd(t, "testdata", "go-library")
 	defer popd()
 
-	outDir, err := ioutil.TempDir("", "go-opine-cmd-test.")
+	outDir, err := os.MkdirTemp("", "go-opine-cmd-test.")
 	require.NoError(t, err)
 	defer os.RemoveAll(outDir)
 

--- a/internal/cmd/util.go
+++ b/internal/cmd/util.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/google/subcommands"
 )
@@ -43,7 +43,7 @@ func ensureNoArgs(f *flag.FlagSet) bool {
 
 // closedTempFile creates a temp file, closes it, and returns the file path.
 func closedTempFile(dir, pattern string) (string, error) {
-	tmpCov, err := ioutil.TempFile(dir, pattern)
+	tmpCov, err := os.CreateTemp(dir, pattern)
 	if err != nil {
 		return "", err
 	}

--- a/internal/coverage/coverage_test.go
+++ b/internal/coverage/coverage_test.go
@@ -3,7 +3,6 @@ package coverage
 import (
 	"bufio"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,7 +42,7 @@ func Test_CoverProfile(t *testing.T) {
 	profiles, err := cover.ParseProfiles(inPath)
 	require.NoError(t, err)
 
-	outDir, err := ioutil.TempDir("", "go-opine-coverage-test.")
+	outDir, err := os.MkdirTemp("", "go-opine-coverage-test.")
 	require.NoError(t, err)
 	defer os.RemoveAll(outDir)
 	outPath := filepath.Join(outDir, "cover.out")
@@ -64,7 +63,7 @@ func Test_XML(t *testing.T) {
 	profiles, err := cover.ParseProfiles(inPath)
 	require.NoError(t, err)
 
-	outDir, err := ioutil.TempDir("", "go-opine-coverage-test.")
+	outDir, err := os.MkdirTemp("", "go-opine-coverage-test.")
 	require.NoError(t, err)
 	defer os.RemoveAll(outDir)
 	outPath := filepath.Join(outDir, "lang-go-cobertura.xml")

--- a/internal/gotest/doc.go
+++ b/internal/gotest/doc.go
@@ -2,20 +2,20 @@
 //
 // This package contains a LOT of code to
 //
-//   1. reassemble test events into test results (each test is reported as
-//      a bunch of "output" actions followed by a "pass", "fail", or "skip"
-//      action), and
-//   2. order the results so that when printed each test can be easily
-//      associated with the package it is in.
+//  1. reassemble test events into test results (each test is reported as
+//     a bunch of "output" actions followed by a "pass", "fail", or "skip"
+//     action), and
+//  2. order the results so that when printed each test can be easily
+//     associated with the package it is in.
 //
 // However, all of the above complexity is hidden behind a relatively
 // simple API. Here is an example:
 //
-//     var verboseOutput bytes.Buffer
-//     err := gotest.Run(
-//         gotest.QuietOutput(os.Stdout),
-//         gotest.VerboseOutput(&verboseOutput),
-//     )
+//	var verboseOutput bytes.Buffer
+//	err := gotest.Run(
+//	    gotest.QuietOutput(os.Stdout),
+//	    gotest.VerboseOutput(&verboseOutput),
+//	)
 //
 // The above example also shows why we use "go test -v -json" at all: we
 // want to be able to construct both the verbose output (for generating

--- a/internal/gotest/event_test.go
+++ b/internal/gotest/event_test.go
@@ -88,7 +88,7 @@ func Test_eventStreamParser_Parse_unmarshalError(t *testing.T) {
 
 func Test_eventStreamParser_Parse_acceptError(t *testing.T) {
 	expectedErr := errors.New("failed to parse")
-	tested := newEventStreamParser(eventAccepterFunc(func(e event) error { return expectedErr }))
+	tested := newEventStreamParser(eventAccepterFunc(func(event) error { return expectedErr }))
 	err := tested.Parse(strings.NewReader("{}\n"))
 	require.Equal(t, expectedErr, err)
 }

--- a/internal/gotest/output_test.go
+++ b/internal/gotest/output_test.go
@@ -30,7 +30,7 @@ ok  	oss.indeed.com/go/go-opine/internal/cmd	11.527s
 
 func Test_removeCoverageOutput_Accept_error(t *testing.T) {
 	expectedErr := errors.New("failed to parse")
-	tested := newRemoveCoverageOutput(resultAccepterFunc(func(res result) error { return expectedErr }))
+	tested := newRemoveCoverageOutput(resultAccepterFunc(func(result) error { return expectedErr }))
 	err := tested.Accept(result{})
 	require.Equal(t, expectedErr, err)
 }
@@ -125,6 +125,6 @@ type errorWriter struct {
 	err error
 }
 
-func (e *errorWriter) Write(p []byte) (int, error) {
+func (e *errorWriter) Write([]byte) (int, error) {
 	return 0, e.err
 }

--- a/internal/gotest/result.go
+++ b/internal/gotest/result.go
@@ -132,10 +132,10 @@ func (a *resultAggregator) setErr(err error) {
 // immediately it will cause confusion regarding which package each test
 // is in. For example take the following output:
 //
-//     === RUN   Test_Cmd_optionLog
-//     --- PASS: Test_Cmd_optionLog (0.01s)
-//     PASS
-//     ok  	oss.indeed.com/go/go-opine/internal/run	(cached)
+//	=== RUN   Test_Cmd_optionLog
+//	--- PASS: Test_Cmd_optionLog (0.01s)
+//	PASS
+//	ok  	oss.indeed.com/go/go-opine/internal/run	(cached)
 //
 // The only way you can tell the Test_Cmd_optionLog package is
 // oss.indeed.com/go/go-opine/internal/run is by the fact that the package

--- a/internal/gotest/result_test.go
+++ b/internal/gotest/result_test.go
@@ -26,8 +26,8 @@ func Test_resultAccepter_Accept(t *testing.T) {
 func Test_resultAccepter_Accept_error(t *testing.T) {
 	expectedErr := errors.New("fail boat")
 	tested := newMultiResultAccepter(
-		resultAccepterFunc(func(res result) error { return expectedErr }),
-		resultAccepterFunc(func(res result) error { require.Fail(t, "should not be called"); return nil }),
+		resultAccepterFunc(func(result) error { return expectedErr }),
+		resultAccepterFunc(func(result) error { require.Fail(t, "should not be called"); return nil }),
 	)
 	require.Equal(t, expectedErr, tested.Accept(result{}))
 }
@@ -137,7 +137,7 @@ func Test_resultAggregator_Accept(t *testing.T) {
 			event{
 				Action:  "pass",
 				Package: "indeed.com/some/other/pkg",
-				Output: "ok  	indeed.com/some/other/pkg	0.091s\n",
+				Output:  "ok  	indeed.com/some/other/pkg	0.091s\n",
 				Elapsed: 0.43,
 			},
 		),
@@ -150,7 +150,7 @@ func Test_resultAggregator_Accept(t *testing.T) {
 					Package: "indeed.com/some/other/pkg",
 				},
 				Outcome: "pass",
-				Output: "ok  	indeed.com/some/other/pkg	0.091s\n",
+				Output:  "ok  	indeed.com/some/other/pkg	0.091s\n",
 				Elapsed: 430 * time.Millisecond,
 			},
 		},
@@ -165,7 +165,7 @@ func Test_resultAggregator_Accept(t *testing.T) {
 			event{
 				Action:  "skip",
 				Package: "indeed.com/some/skipped/pkg",
-				Output: "?   	oss.indeed.com/go/go-opine	[no test files]\n",
+				Output:  "?   	oss.indeed.com/go/go-opine	[no test files]\n",
 				Elapsed: 0,
 			},
 		),
@@ -178,7 +178,7 @@ func Test_resultAggregator_Accept(t *testing.T) {
 					Package: "indeed.com/some/skipped/pkg",
 				},
 				Outcome: "skip",
-				Output: "?   	oss.indeed.com/go/go-opine	[no test files]\n",
+				Output:  "?   	oss.indeed.com/go/go-opine	[no test files]\n",
 			},
 		},
 		results,
@@ -222,7 +222,7 @@ func Test_resultAggregator_Accept(t *testing.T) {
 			event{
 				Action:  "fail",
 				Package: "indeed.com/some/pkg",
-				Output: "FAIL	indeed.com/some/pkg	4.321s\n",
+				Output:  "FAIL	indeed.com/some/pkg	4.321s\n",
 				Elapsed: 4.321,
 			},
 		),
@@ -235,7 +235,7 @@ func Test_resultAggregator_Accept(t *testing.T) {
 					Package: "indeed.com/some/pkg",
 				},
 				Outcome: "fail",
-				Output: "FAIL	indeed.com/some/pkg	4.321s\n",
+				Output:  "FAIL	indeed.com/some/pkg	4.321s\n",
 				Elapsed: 4321 * time.Millisecond,
 			},
 		},
@@ -250,7 +250,7 @@ func Test_resultAggregator_Accept_error(t *testing.T) {
 	expectedErr := errors.New("fail boat")
 	called := false
 	tested := newResultAggregator(
-		resultAccepterFunc(func(res result) error { require.False(t, called); called = true; return expectedErr }),
+		resultAccepterFunc(func(result) error { require.False(t, called); called = true; return expectedErr }),
 	)
 	require.Equal(t, expectedErr, tested.Accept(event{Action: "pass"}))
 	require.Equal(t, expectedErr, errors.Unwrap(tested.Accept(event{Action: "pass"})))
@@ -258,7 +258,7 @@ func Test_resultAggregator_Accept_error(t *testing.T) {
 }
 
 func Test_resultAggregator_CheckAllEventsConsumed_unconsumedEvents(t *testing.T) {
-	tested := newResultAggregator(resultAccepterFunc(func(res result) error { return nil }))
+	tested := newResultAggregator(resultAccepterFunc(func(result) error { return nil }))
 	require.NoError(t, tested.Accept(event{Package: "BLAH"}))
 	require.Error(t, tested.CheckAllEventsConsumed())
 }
@@ -429,7 +429,7 @@ func Test_resultPackageGrouper_Accept_error(t *testing.T) {
 	expectedErr := errors.New("fail boat")
 	called := false
 	tested := newResultPackageGrouper(
-		resultAccepterFunc(func(res result) error { require.False(t, called); called = true; return expectedErr }),
+		resultAccepterFunc(func(result) error { require.False(t, called); called = true; return expectedErr }),
 	)
 	require.Equal(t, expectedErr, tested.Accept(result{}))
 	require.Equal(t, expectedErr, errors.Unwrap(tested.Accept(result{})))
@@ -437,7 +437,7 @@ func Test_resultPackageGrouper_Accept_error(t *testing.T) {
 }
 
 func Test_resultPackageGrouper_CheckAllResultsConsumed_incompletePackages(t *testing.T) {
-	tested := newResultPackageGrouper(resultAccepterFunc(func(res result) error { return nil }))
+	tested := newResultPackageGrouper(resultAccepterFunc(func(result) error { return nil }))
 	require.NoError(t, tested.Accept(result{Key: resultKey{Package: "MyPackage", Test: "MyTest"}}))
 	require.Error(t, tested.CheckAllResultsConsumed())
 }

--- a/internal/gotest/run_test.go
+++ b/internal/gotest/run_test.go
@@ -2,7 +2,6 @@ package gotest
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -31,7 +30,7 @@ func Test_Run_allOptions(t *testing.T) {
 	popd := pushd(t, "testdata")
 	defer popd()
 
-	f, err := ioutil.TempFile("", "go-opine-gotest.")
+	f, err := os.CreateTemp("", "go-opine-gotest.")
 	require.NoError(t, err)
 	covPath := f.Name()
 	require.NoError(t, f.Close())
@@ -77,19 +76,19 @@ func Test_Run_fail(t *testing.T) {
 }
 
 func Test_parseGoTestJSONOutput_parseError(t *testing.T) {
-	err := parseGoTestJSONOutput(strings.NewReader("NOT JSON!"), resultAccepterFunc(func(res result) error { return nil }))
+	err := parseGoTestJSONOutput(strings.NewReader("NOT JSON!"), resultAccepterFunc(func(result) error { return nil }))
 	require.Error(t, err)
 }
 
 func Test_parseGoTestJSONOutput_unconsumedEvents(t *testing.T) {
 	const eventJSON = `{"Time":"2019-09-26T13:27:17.563229183Z","Action":"output","Package":"oss.indeed.com/go/go-opine/internal/cmd","Test":"Test_testCmd_impl","Output":"--- PASS: Test_testCmd_impl (1.93s)\n"}`
-	err := parseGoTestJSONOutput(strings.NewReader(eventJSON), resultAccepterFunc(func(res result) error { return nil }))
+	err := parseGoTestJSONOutput(strings.NewReader(eventJSON), resultAccepterFunc(func(result) error { return nil }))
 	require.Error(t, err)
 }
 
 func Test_parseGoTestJSONOutput_unconsumedResults(t *testing.T) {
 	const eventJSON = `{"Time":"2019-09-26T13:27:17.56324465Z","Action":"pass","Package":"oss.indeed.com/go/go-opine/internal/cmd","Test":"Test_testCmd_impl","Elapsed":1.93}`
-	err := parseGoTestJSONOutput(strings.NewReader(eventJSON), resultAccepterFunc(func(res result) error { return nil }))
+	err := parseGoTestJSONOutput(strings.NewReader(eventJSON), resultAccepterFunc(func(result) error { return nil }))
 	require.Error(t, err)
 }
 

--- a/internal/gotest/workaround_go_issue_35180_test.go
+++ b/internal/gotest/workaround_go_issue_35180_test.go
@@ -36,7 +36,7 @@ FAIL	example.com	3.452s
 			{
 				Key:     resultKey{Package: issueRes.Key.Package},
 				Outcome: issueRes.Outcome,
-				Output: "FAIL	example.com	3.452s\n",
+				Output:  "FAIL	example.com	3.452s\n",
 				Elapsed: 3452 * time.Millisecond,
 			},
 		},

--- a/internal/junit/junit_test.go
+++ b/internal/junit/junit_test.go
@@ -1,7 +1,6 @@
 package junit
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,7 +11,7 @@ import (
 )
 
 func Test_Write(t *testing.T) {
-	outDir, err := ioutil.TempDir("", "go-opine-junit-test.")
+	outDir, err := os.MkdirTemp("", "go-opine-junit-test.")
 	require.NoError(t, err)
 	defer os.RemoveAll(outDir)
 	goTestOutput, _, err := run.Cmd("go", run.Args("test", "-v", "./testdata"))

--- a/internal/printing/error_writer_test.go
+++ b/internal/printing/error_writer_test.go
@@ -10,6 +10,6 @@ type errorWriter struct {
 }
 
 // Always returns n bytes written and errorWriterErr.
-func (f errorWriter) Write(p []byte) (int, error) {
+func (f errorWriter) Write([]byte) (int, error) {
 	return f.n, errorWriterErr
 }

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -28,23 +28,23 @@ type cmdinfo struct {
 // exit code is non-zero.
 //
 // By default Cmd will write the following to os.Stdout:
-//   * A message before running the command that indicates the command that
+//   - A message before running the command that indicates the command that
 //     will be run, including the args.
-//   * The stdout of the command. Each line will be prefixed with "  > ". Note
+//   - The stdout of the command. Each line will be prefixed with "  > ". Note
 //     that the returned stdout will not have this prefix.
-//   * The stderr of the command. Each line will be prefixed with "  ! ". Note
+//   - The stderr of the command. Each line will be prefixed with "  ! ". Note
 //     that the returned stderr will not have this prefix.
-//   * A message when the command completes indicating whether it completed
+//   - A message when the command completes indicating whether it completed
 //     successfully or not, and what exit code it returned in the case of a
 //     failure.
 //
 // The above output can be configured as follows:
-//   * Use Log to change the output destination (from os.Stdout) to the
+//   - Use Log to change the output destination (from os.Stdout) to the
 //     provided io.Writer. Use io.Discard if you do not want anything
 //     printed.
-//   * Use SuppressStdout to prevent the stdout from being written. It will
+//   - Use SuppressStdout to prevent the stdout from being written. It will
 //     still be returned.
-//   * Use SuppressStderr to prevent the stderr from being written. It will
+//   - Use SuppressStderr to prevent the stderr from being written. It will
 //     still be returned.
 func Cmd(command string, args []string, opts ...Option) (string, string, error) {
 	sp := cmdinfo{
@@ -88,12 +88,12 @@ func Cmd(command string, args []string, opts ...Option) (string, string, error) 
 // Args returns the provided variadic args as a slice. This allows
 // you to use Cmd like this:
 //
-//     run.Cmd("echo", run.Args("hello", "world"))
+//	run.Cmd("echo", run.Args("hello", "world"))
 //
 // The above is arguably slightly more readable than using a []string
 // directly:
 //
-//     run.Cmd("echo", []string{"hello", "world"})
+//	run.Cmd("echo", []string{"hello", "world"})
 func Args(args ...string) []string {
 	return args
 }


### PR DESCRIPTION
  - Build with Go 1.23
  - Address deprecation warnings
  - Use golangci-lint 1.64.8 & remove deprecated linters
  - Address linter warnings
  - Use go-groups 1.1.3