### PR TITLE
GOPHERS-1255: Fixing go-opine errors on OSX

### DIFF
--- a/internal/gotest/result.go
+++ b/internal/gotest/result.go
@@ -113,7 +113,7 @@ func (a *resultAggregator) Accept(e event) error {
 
 // filterBuildWarnings returns a copy of the supplied events map after removing
 // any resultKeys that only contain "build-output" actions. These actions
-// without a cooresponding build-fail event are just build warnings and do not
+// without a corresponding build-fail event are just build warnings and do not
 // change the output of the tests.
 func filterBuildWarnings(events map[resultKey][]event) map[resultKey][]event {
 	filtered := make(map[resultKey][]event, len(events))


### PR DESCRIPTION
The problem on OSX is warnings from the linker showing up as "build-output" actions but without a corresponding "build-fail". There is no "build-success" or any such similar build action, so these warnings will always dangle. It is worth mentioning, there is no indication that the "build-output" actions are limited to warnings. Doing some testing across multiple projects I only saw warning messages, but that certainly is not a comprehensive search. We could do a search of the Output string to see if "warning" appears there, but that seems brittle to me.

Given the above, I have updated the code to filter "build-output" messages by package when those messages appear in isolation. If there are other unconsumed events, we do not hide them.